### PR TITLE
fix: scope skill/knowledge cleanup to prevent cross-team deletion

### DIFF
--- a/cli/src/__tests__/base-utils.test.ts
+++ b/cli/src/__tests__/base-utils.test.ts
@@ -1,6 +1,21 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { slugify, sanitizeText, sanitizeMarkerContent, escapeYamlString } from "../adapters/base.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  slugify,
+  sanitizeText,
+  sanitizeMarkerContent,
+  escapeYamlString,
+  cleanupSkillDirs,
+  listSkillDirIds,
+  collectTeamSkillIds,
+  deleteKnowledgeFiles,
+  knowledgeFileName,
+  BUILTIN_SKILL_IDS,
+  type TeamDefinition,
+} from "../adapters/base.js";
 
 // ---------------------------------------------------------------------------
 // slugify
@@ -119,5 +134,189 @@ describe("escapeYamlString", () => {
 
   it("handles empty string", () => {
     assert.equal(escapeYamlString(""), "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupSkillDirs
+// ---------------------------------------------------------------------------
+
+describe("cleanupSkillDirs", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trc-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("only removes directories matching the provided skill IDs", () => {
+    fs.mkdirSync(path.join(tmpDir, "trc-foo"));
+    fs.mkdirSync(path.join(tmpDir, "trc-bar"));
+    fs.mkdirSync(path.join(tmpDir, "trc-baz"));
+
+    const count = cleanupSkillDirs(tmpDir, ["foo", "bar"]);
+
+    assert.equal(count, 2);
+    assert.ok(!fs.existsSync(path.join(tmpDir, "trc-foo")));
+    assert.ok(!fs.existsSync(path.join(tmpDir, "trc-bar")));
+    assert.ok(fs.existsSync(path.join(tmpDir, "trc-baz")), "trc-baz should survive");
+  });
+
+  it("leaves other teams' trc-* dirs untouched", () => {
+    fs.mkdirSync(path.join(tmpDir, "trc-team-a-skill"));
+    fs.mkdirSync(path.join(tmpDir, "trc-team-b-skill"));
+
+    cleanupSkillDirs(tmpDir, ["team-a-skill"]);
+
+    assert.ok(!fs.existsSync(path.join(tmpDir, "trc-team-a-skill")));
+    assert.ok(fs.existsSync(path.join(tmpDir, "trc-team-b-skill")));
+  });
+
+  it("returns 0 when no matching dirs exist", () => {
+    fs.mkdirSync(path.join(tmpDir, "trc-other"));
+    assert.equal(cleanupSkillDirs(tmpDir, ["nonexistent"]), 0);
+    assert.ok(fs.existsSync(path.join(tmpDir, "trc-other")));
+  });
+
+  it("returns 0 for empty skill IDs list", () => {
+    fs.mkdirSync(path.join(tmpDir, "trc-foo"));
+    assert.equal(cleanupSkillDirs(tmpDir, []), 0);
+    assert.ok(fs.existsSync(path.join(tmpDir, "trc-foo")));
+  });
+
+  it("returns 0 for non-existent directory", () => {
+    assert.equal(cleanupSkillDirs("/nonexistent/path", ["foo"]), 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listSkillDirIds
+// ---------------------------------------------------------------------------
+
+describe("listSkillDirIds", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trc-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns IDs from trc-* directories", () => {
+    fs.mkdirSync(path.join(tmpDir, "trc-foo"));
+    fs.mkdirSync(path.join(tmpDir, "trc-bar"));
+    fs.writeFileSync(path.join(tmpDir, "trc-not-a-dir.txt"), "");
+
+    const ids = listSkillDirIds(tmpDir);
+    assert.deepEqual(ids.sort(), ["bar", "foo"]);
+  });
+
+  it("returns empty array for non-existent directory", () => {
+    assert.deepEqual(listSkillDirIds("/nonexistent/path"), []);
+  });
+
+  it("returns empty array when no trc-* dirs exist", () => {
+    assert.deepEqual(listSkillDirIds(tmpDir), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteKnowledgeFiles
+// ---------------------------------------------------------------------------
+
+describe("deleteKnowledgeFiles", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trc-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("deletes only the file matching the specific slug", () => {
+    fs.writeFileSync(path.join(tmpDir, "knowledge-frontend.md"), "data");
+    fs.writeFileSync(path.join(tmpDir, "knowledge-ops.md"), "data");
+
+    const deleted = deleteKnowledgeFiles(tmpDir, "frontend");
+
+    assert.equal(deleted.length, 1);
+    assert.ok(!fs.existsSync(path.join(tmpDir, "knowledge-frontend.md")));
+    assert.ok(fs.existsSync(path.join(tmpDir, "knowledge-ops.md")));
+  });
+
+  it("treats 'team' as a literal slug, not a wildcard", () => {
+    fs.writeFileSync(path.join(tmpDir, "knowledge-team.md"), "data");
+    fs.writeFileSync(path.join(tmpDir, "knowledge-other.md"), "data");
+
+    const deleted = deleteKnowledgeFiles(tmpDir, "team");
+
+    assert.equal(deleted.length, 1);
+    assert.ok(!fs.existsSync(path.join(tmpDir, "knowledge-team.md")));
+    assert.ok(fs.existsSync(path.join(tmpDir, "knowledge-other.md")));
+  });
+
+  it("deletes nothing when slug is empty", () => {
+    fs.writeFileSync(path.join(tmpDir, "knowledge-foo.md"), "data");
+
+    const deleted = deleteKnowledgeFiles(tmpDir, "");
+
+    assert.equal(deleted.length, 0);
+    assert.ok(fs.existsSync(path.join(tmpDir, "knowledge-foo.md")));
+  });
+
+  it("returns empty array for non-existent directory", () => {
+    assert.deepEqual(deleteKnowledgeFiles("/nonexistent/path", "foo"), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// knowledgeFileName
+// ---------------------------------------------------------------------------
+
+describe("knowledgeFileName", () => {
+  it("builds file name from slug", () => {
+    assert.equal(knowledgeFileName("my-team"), "knowledge-my-team.md");
+  });
+
+  it("falls back to 'team' for empty slug", () => {
+    assert.equal(knowledgeFileName(""), "knowledge-team.md");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectTeamSkillIds
+// ---------------------------------------------------------------------------
+
+describe("collectTeamSkillIds", () => {
+  it("returns built-in IDs when team has no skills", () => {
+    const team: TeamDefinition = { name: "test", members: [] };
+    const ids = collectTeamSkillIds(team);
+    assert.deepEqual(ids, [...BUILTIN_SKILL_IDS]);
+  });
+
+  it("returns team skill IDs plus built-in IDs", () => {
+    const team: TeamDefinition = {
+      name: "test",
+      members: [],
+      skills: [
+        { id: "custom-skill", body: "do stuff" },
+        { id: "another", body: "more stuff" },
+      ],
+    };
+    const ids = collectTeamSkillIds(team);
+    assert.deepEqual(ids, ["custom-skill", "another", ...BUILTIN_SKILL_IDS]);
+  });
+
+  it("returns built-in IDs when skills array is empty", () => {
+    const team: TeamDefinition = { name: "test", members: [], skills: [] };
+    const ids = collectTeamSkillIds(team);
+    assert.deepEqual(ids, [...BUILTIN_SKILL_IDS]);
   });
 });

--- a/cli/src/adapters/base.ts
+++ b/cli/src/adapters/base.ts
@@ -106,8 +106,9 @@ export interface PlatformAdapter {
   /** Return the absolute path to this adapter's knowledge file. */
   getKnowledgePath(scope?: TeamScope): string;
   /** Remove everything teamrc installed for this platform. Returns list of actions taken.
-   *  When scope is provided, only removes files for that scope. */
-  uninstall(scope?: TeamScope): string[];
+   *  When scope is provided, only removes files for that scope.
+   *  When skillIds is provided, only removes skill dirs for those IDs (avoids deleting other teams' skills in shared roots). */
+  uninstall(scope?: TeamScope, skillIds?: string[]): string[];
 }
 
 /** Write a native SKILL.md file for a skill in the given base directory */
@@ -127,14 +128,27 @@ export function writeSkillDir(baseDir: string, skill: Skill): void {
   fs.writeFileSync(path.join(skillDir, "SKILL.md"), lines.join("\n") + "\n");
 }
 
-/** Remove all trc-* skill directories under a base directory */
-export function cleanupSkillDirs(baseDir: string): number {
-  if (!fs.existsSync(baseDir)) return 0;
-  const dirs = fs.readdirSync(baseDir).filter((d) => d.startsWith("trc-"));
-  for (const d of dirs) {
-    fs.rmSync(path.join(baseDir, d), { recursive: true, force: true });
+/** Remove trc-* skill directories for the given skill IDs under a base directory.
+ *  Only removes directories matching the provided IDs, leaving other teams' skills intact. */
+export function cleanupSkillDirs(baseDir: string, skillIds: string[]): number {
+  if (!fs.existsSync(baseDir) || skillIds.length === 0) return 0;
+  let count = 0;
+  for (const id of skillIds) {
+    const dirPath = path.join(baseDir, `trc-${id}`);
+    if (fs.existsSync(dirPath)) {
+      fs.rmSync(dirPath, { recursive: true, force: true });
+      count++;
+    }
   }
-  return dirs.length;
+  return count;
+}
+
+/** List skill IDs from existing trc-* directories under a base directory */
+export function listSkillDirIds(baseDir: string): string[] {
+  if (!fs.existsSync(baseDir)) return [];
+  return fs.readdirSync(baseDir)
+    .filter((d) => d.startsWith("trc-") && fs.statSync(path.join(baseDir, d)).isDirectory())
+    .map((d) => d.slice(4));
 }
 
 /** List trc-* files in a directory, filtered by extension */
@@ -234,26 +248,17 @@ export function knowledgeFileName(teamSlug: string): string {
   return `knowledge-${teamSlug || "team"}.md`;
 }
 
-/** Delete knowledge file(s) in a directory. When slug is the fallback "team",
- *  glob-deletes all knowledge-*.md to handle the case where the real slug is unknown.
- *  Otherwise deletes only the specific slug's file. Returns list of deleted paths. */
+/** Delete the knowledge file for a specific team slug. If slug is empty/falsy,
+ *  deletes nothing (fail closed) to avoid wiping unrelated teams' files.
+ *  Returns list of deleted paths. */
 export function deleteKnowledgeFiles(dir: string, teamSlug: string): string[] {
   if (!fs.existsSync(dir)) return [];
+  if (!teamSlug) return [];
   const deleted: string[] = [];
-  if (teamSlug === "team") {
-    // Slug unknown (e.g., YAML already deleted)  --  clean up all knowledge files
-    const files = fs.readdirSync(dir).filter((f) => f.startsWith("knowledge-") && f.endsWith(".md"));
-    for (const f of files) {
-      const full = path.join(dir, f);
-      fs.unlinkSync(full);
-      deleted.push(full);
-    }
-  } else {
-    const full = path.join(dir, knowledgeFileName(teamSlug));
-    if (fs.existsSync(full)) {
-      fs.unlinkSync(full);
-      deleted.push(full);
-    }
+  const full = path.join(dir, knowledgeFileName(teamSlug));
+  if (fs.existsSync(full)) {
+    fs.unlinkSync(full);
+    deleted.push(full);
   }
   return deleted;
 }
@@ -407,6 +412,21 @@ export function resolveAgentSkills(
     (s) => s.alwaysApply && !assigned.some((a) => a.id === s.id),
   );
   return [...alwaysOn, ...assigned];
+}
+
+/** Collect all skill IDs from a team definition, including built-in skill IDs.
+ *  Used to scope cleanupSkillDirs to only this team's skills. */
+export function collectTeamSkillIds(team: TeamDefinition): string[] {
+  const ids: string[] = [];
+  if (team.skills) {
+    for (const skill of team.skills) {
+      ids.push(skill.id);
+    }
+  }
+  for (const id of BUILTIN_SKILL_IDS) {
+    ids.push(id);
+  }
+  return ids;
 }
 
 export function getAdapter(platform: string, teamSlug?: string): PlatformAdapter {

--- a/cli/src/adapters/claude-code.ts
+++ b/cli/src/adapters/claude-code.ts
@@ -16,6 +16,8 @@ import {
   upsertMarkerBlock,
   removeMarkerBlock,
   cleanupSkillDirs,
+  listSkillDirIds,
+  collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
   createBuiltInSkills,
@@ -202,10 +204,11 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
   }
 
   private writeSkillsAsNativeFiles(team: TeamDefinition, scope: TeamScope): void {
+    const allSkillIds = collectTeamSkillIds(team);
     if (!team.skills || team.skills.length === 0) {
-      // Still clean up old files even if no skills
+      // Still clean up old files even if no skills — use existing dirs to find our stale skills
       deleteTrcFiles(this.rulesDir(scope));
-      cleanupSkillDirs(this.skillsDir(scope));
+      cleanupSkillDirs(this.skillsDir(scope), listSkillDirIds(this.skillsDir(scope)));
       return;
     }
 
@@ -214,7 +217,7 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
 
     // Clean up old files before writing new ones
     deleteTrcFiles(rulesDir);
-    cleanupSkillDirs(skillsBaseDir);
+    cleanupSkillDirs(skillsBaseDir, allSkillIds);
 
     for (const skill of team.skills) {
       if (typeof skill.body !== "string") continue;
@@ -311,7 +314,7 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
     fs.writeFileSync(p, content);
   }
 
-  uninstall(requestedScope?: TeamScope): string[] {
+  uninstall(requestedScope?: TeamScope, skillIds?: string[]): string[] {
     const actions: string[] = [];
     const { dir, scope } = requestedScope
       ? { dir: this.agentsDir(requestedScope), scope: requestedScope }
@@ -336,18 +339,12 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
       actions.push(`Deleted ${ruleFiles.length} native skill rule(s) from ${rulesDir}`);
     }
 
-    // Delete native skill directories
+    // Delete native skill directories — scoped to known skill IDs when available
     const skillsDir = this.skillsDir(scope);
-    if (fs.existsSync(skillsDir)) {
-      const trcSkillDirs = fs.readdirSync(skillsDir).filter((f) => {
-        return f.startsWith("trc-") && fs.statSync(path.join(skillsDir, f)).isDirectory();
-      });
-      for (const f of trcSkillDirs) {
-        fs.rmSync(path.join(skillsDir, f), { recursive: true, force: true });
-      }
-      if (trcSkillDirs.length > 0) {
-        actions.push(`Deleted ${trcSkillDirs.length} native skill directory(ies) from ${skillsDir}`);
-      }
+    const idsToClean = skillIds ?? listSkillDirIds(skillsDir);
+    const skillCount = cleanupSkillDirs(skillsDir, idsToClean);
+    if (skillCount > 0) {
+      actions.push(`Deleted ${skillCount} native skill directory(ies) from ${skillsDir}`);
     }
 
     // Delete team knowledge

--- a/cli/src/adapters/codex.ts
+++ b/cli/src/adapters/codex.ts
@@ -12,6 +12,8 @@ import {
   removeMarkerBlock,
   writeSkillDir,
   cleanupSkillDirs,
+  listSkillDirIds,
+  collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
   type FileAction,
@@ -132,7 +134,7 @@ export class CodexAdapter implements PlatformAdapter {
     const teamWithKnowledge = enrichTeamKnowledgeSkill(team, `.teamrc/${knowledgeFileName(this.teamSlug)}`, this.readKnowledge());
 
     // Route skills: alwaysApply/globs → inline in AGENTS.md, on-demand → .agents/skills/
-    cleanupSkillDirs(this.skillsDir());
+    cleanupSkillDirs(this.skillsDir(), collectTeamSkillIds(teamWithKnowledge));
     if (teamWithKnowledge.skills) {
       const dir = this.skillsDir();
       for (const skill of teamWithKnowledge.skills) {
@@ -330,7 +332,7 @@ export class CodexAdapter implements PlatformAdapter {
     fs.writeFileSync(p, content);
   }
 
-  uninstall(_scope?: TeamScope): string[] {
+  uninstall(_scope?: TeamScope, skillIds?: string[]): string[] {
     const actions: string[] = [];
 
     // Clean up subagent TOML files
@@ -347,8 +349,9 @@ export class CodexAdapter implements PlatformAdapter {
       actions.push("Removed teamrc section from .codex/config.toml");
     }
 
-    // Clean up skill directories
-    const skillCount = cleanupSkillDirs(this.skillsDir());
+    // Clean up skill directories — scoped to known skill IDs when available
+    const idsToClean = skillIds ?? listSkillDirIds(this.skillsDir());
+    const skillCount = cleanupSkillDirs(this.skillsDir(), idsToClean);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} teamrc codex skill(s)`);
     }

--- a/cli/src/adapters/cursor.ts
+++ b/cli/src/adapters/cursor.ts
@@ -14,6 +14,8 @@ import {
   upsertMarkerBlock,
   removeMarkerBlock,
   cleanupSkillDirs,
+  listSkillDirIds,
+  collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
   createBuiltInSkills,
@@ -167,7 +169,7 @@ export class CursorAdapter implements PlatformAdapter {
     for (const f of oldRules) {
       fs.unlinkSync(path.join(this.rulesDir(), f));
     }
-    cleanupSkillDirs(this.skillsDir());
+    cleanupSkillDirs(this.skillsDir(), collectTeamSkillIds(teamWithKnowledge));
 
     // Route skills: alwaysApply/globs → .mdc rule, otherwise → SKILL.md
     if (teamWithKnowledge.skills) {
@@ -348,7 +350,7 @@ ${body}
     fs.writeFileSync(p, content);
   }
 
-  uninstall(_scope?: TeamScope): string[] {
+  uninstall(_scope?: TeamScope, skillIds?: string[]): string[] {
     const actions: string[] = [];
 
     // Clean up subagent .md files
@@ -369,8 +371,9 @@ ${body}
       actions.push(`Deleted ${trcRules.length} teamrc cursor rule(s)`);
     }
 
-    // Clean up skill directories
-    const skillCount = cleanupSkillDirs(this.skillsDir());
+    // Clean up skill directories — scoped to known skill IDs when available
+    const idsToClean = skillIds ?? listSkillDirIds(this.skillsDir());
+    const skillCount = cleanupSkillDirs(this.skillsDir(), idsToClean);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} teamrc cursor skill(s)`);
     }

--- a/cli/src/adapters/gemini.ts
+++ b/cli/src/adapters/gemini.ts
@@ -17,6 +17,8 @@ import {
   removeMarkerBlock,
   writeSkillDir,
   cleanupSkillDirs,
+  listSkillDirIds,
+  collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
   createBuiltInSkills,
@@ -176,8 +178,9 @@ export class GeminiAdapter implements PlatformAdapter {
     // Write to both .agents/skills/ (Gemini CLI) and .agent/skills/ (Antigravity)
     const skillDir = this.skillsDir(scope);
     const antigravityDir = this.antigravitySkillsDir(scope);
-    cleanupSkillDirs(skillDir);
-    cleanupSkillDirs(antigravityDir);
+    const allSkillIds = collectTeamSkillIds(teamWithKnowledge);
+    cleanupSkillDirs(skillDir, allSkillIds);
+    cleanupSkillDirs(antigravityDir, allSkillIds);
     if (teamWithKnowledge.skills) {
       for (const skill of teamWithKnowledge.skills) {
         if (!skill.alwaysApply && !(skill.globs && skill.globs.length > 0)) {
@@ -274,7 +277,7 @@ export class GeminiAdapter implements PlatformAdapter {
     fs.writeFileSync(p, content);
   }
 
-  uninstall(requestedScope?: TeamScope): string[] {
+  uninstall(requestedScope?: TeamScope, skillIds?: string[]): string[] {
     const actions: string[] = [];
     const { dir, scope } = requestedScope
       ? { dir: this.agentsDir(requestedScope), scope: requestedScope }
@@ -292,8 +295,10 @@ export class GeminiAdapter implements PlatformAdapter {
     // Delete native skill directories (Gemini CLI + Antigravity)
     const skillsDir = this.skillsDir(scope);
     const antigravityDir = this.antigravitySkillsDir(scope);
-    const skillCount = cleanupSkillDirs(skillsDir);
-    const antigravityCount = cleanupSkillDirs(antigravityDir);
+    const idsToClean = skillIds ?? listSkillDirIds(skillsDir);
+    const antigravityIds = skillIds ?? listSkillDirIds(antigravityDir);
+    const skillCount = cleanupSkillDirs(skillsDir, idsToClean);
+    const antigravityCount = cleanupSkillDirs(antigravityDir, antigravityIds);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} skill directory(ies) from ${skillsDir}`);
     }

--- a/cli/src/adapters/openclaw.ts
+++ b/cli/src/adapters/openclaw.ts
@@ -9,6 +9,8 @@ import {
   deleteKnowledgeFiles,
   writeSkillDir,
   cleanupSkillDirs,
+  listSkillDirIds,
+  collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
   createBuiltInSkills,
@@ -178,7 +180,7 @@ export class OpenClawAdapter implements PlatformAdapter {
 
     // Write skills to ~/.openclaw/skills/
     const sharedDir = this.sharedSkillsDir();
-    cleanupSkillDirs(sharedDir);
+    cleanupSkillDirs(sharedDir, collectTeamSkillIds(teamWithKnowledge));
     if (teamWithKnowledge.skills) {
       if (!fs.existsSync(sharedDir)) {
         fs.mkdirSync(sharedDir, { recursive: true });
@@ -275,7 +277,7 @@ export class OpenClawAdapter implements PlatformAdapter {
     fs.writeFileSync(filePath, content);
   }
 
-  uninstall(_scope?: TeamScope): string[] {
+  uninstall(_scope?: TeamScope, skillIds?: string[]): string[] {
     const actions: string[] = [];
     const agentsDir = this.agentsDir();
 
@@ -308,9 +310,10 @@ export class OpenClawAdapter implements PlatformAdapter {
       }
     }
 
-    // Remove trc- skill directories
+    // Remove trc- skill directories — scoped to known skill IDs when available
     const sharedDir = this.sharedSkillsDir();
-    const skillCount = cleanupSkillDirs(sharedDir);
+    const idsToClean = skillIds ?? listSkillDirIds(sharedDir);
+    const skillCount = cleanupSkillDirs(sharedDir, idsToClean);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} shared skill directory(ies) from ${sharedDir}`);
     }

--- a/cli/src/commands/delete.ts
+++ b/cli/src/commands/delete.ts
@@ -4,7 +4,7 @@ import * as p from "@clack/prompts";
 import { loadKeypair, toToken } from "../auth.js";
 import { TeamrcClient } from "../client.js";
 import { loadConfig, detectPlatforms, getRelayUrl } from "../config.js";
-import { getAdapter, slugify } from "../adapters/base.js";
+import { getAdapter, slugify, collectTeamSkillIds } from "../adapters/base.js";
 import { readTeamYaml, TEAM_YAML, GLOBAL_TEAM_YAML } from "../team-yaml.js";
 import {
   globals,
@@ -144,7 +144,8 @@ export function registerDelete(program: Command): void {
       // Disconnect from relay (scoped to match deletion scope)
       if (kp) {
         const token = toToken(kp.publicKey);
-        const relay = projectTeam?.relay ?? globalTeam?.relay;
+        const scopedTeam = deleteScope === "project" ? projectTeam : globalTeam;
+        const relay = scopedTeam?.relay;
         const relayUrl = getRelayUrl(undefined, relay);
         try {
           if (deleteScope === "project") {
@@ -169,11 +170,13 @@ export function registerDelete(program: Command): void {
 
       // Uninstall from each platform
       const uninstallScope = deleteScope;
-      const deleteTeamName = projectTeam?.name ?? globalTeam?.name;
+      const selectedTeam = deleteScope === "project" ? projectTeam : globalTeam;
+      const deleteTeamName = selectedTeam?.name;
       const deleteTeamSlug = deleteTeamName ? slugify(deleteTeamName) : undefined;
+      const teamSkillIds = selectedTeam ? collectTeamSkillIds(selectedTeam) : undefined;
       for (const pl of platforms) {
         const adapter = getAdapter(pl, deleteTeamSlug);
-        const actions = adapter.uninstall(uninstallScope);
+        const actions = adapter.uninstall(uninstallScope, teamSkillIds);
         for (const action of actions) {
           actionLines.push(action);
         }


### PR DESCRIPTION
## Summary

- **cleanupSkillDirs** now takes an explicit list of skill IDs instead of blanket-removing every `trc-*` directory. Syncing Team B no longer wipes Team A's skills in shared roots like `~/.openclaw/skills/`.
- **deleteKnowledgeFiles** no longer wildcard-deletes all `knowledge-*.md` when the slug defaults to `"team"`. Unknown slugs delete nothing (fail closed).
- **delete command** now derives the team slug and relay URL from the selected scope (`--scope global` uses `globalTeam`, not `projectTeam`).

Fixes #2, #3, #4.

## What changed

| File | Change |
|------|--------|
| `adapters/base.ts` | `cleanupSkillDirs(dir, skillIds[])` signature, added `listSkillDirIds`, removed wildcard branch from `deleteKnowledgeFiles` |
| `adapters/*.ts` (all 5) | Pass scoped skill IDs in `writeTeam` and `uninstall` |
| `commands/delete.ts` | Scope-correct team selection for slug, relay, and skill IDs |
| `__tests__/base-utils.test.ts` | 16 new tests covering scoped cleanup, cross-team preservation, wildcard removal, and knowledge file safety |

## Test plan

- [x] `cleanupSkillDirs` only removes dirs matching provided IDs
- [x] `cleanupSkillDirs` leaves other teams' `trc-*` dirs intact
- [x] `deleteKnowledgeFiles("team")` treats it as literal, not wildcard
- [x] `deleteKnowledgeFiles("")` deletes nothing
- [x] `listSkillDirIds` returns correct IDs from existing dirs
- [x] All 40 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)