### PR TITLE
fix: add skill manifest to fully scope cleanup (#2 follow-up)

### DIFF
--- a/cli/src/__tests__/base-utils.test.ts
+++ b/cli/src/__tests__/base-utils.test.ts
@@ -10,6 +10,9 @@ import {
   escapeYamlString,
   cleanupSkillDirs,
   listSkillDirIds,
+  readSkillManifest,
+  writeSkillManifest,
+  removeSkillManifest,
   collectTeamSkillIds,
   deleteKnowledgeFiles,
   knowledgeFileName,
@@ -318,5 +321,57 @@ describe("collectTeamSkillIds", () => {
     const team: TeamDefinition = { name: "test", members: [], skills: [] };
     const ids = collectTeamSkillIds(team);
     assert.deepEqual(ids, [...BUILTIN_SKILL_IDS]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readSkillManifest / writeSkillManifest / removeSkillManifest
+// ---------------------------------------------------------------------------
+
+describe("skill manifest", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trc-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("round-trips skill IDs through write and read", () => {
+    writeSkillManifest(tmpDir, "my-team", ["foo", "bar", "baz"]);
+    const ids = readSkillManifest(tmpDir, "my-team");
+    assert.deepEqual(ids, ["foo", "bar", "baz"]);
+  });
+
+  it("returns empty array when no manifest exists", () => {
+    assert.deepEqual(readSkillManifest(tmpDir, "no-team"), []);
+  });
+
+  it("returns empty array for non-existent directory", () => {
+    assert.deepEqual(readSkillManifest("/nonexistent/path", "team"), []);
+  });
+
+  it("isolates manifests by team slug", () => {
+    writeSkillManifest(tmpDir, "team-a", ["skill-1"]);
+    writeSkillManifest(tmpDir, "team-b", ["skill-2"]);
+    assert.deepEqual(readSkillManifest(tmpDir, "team-a"), ["skill-1"]);
+    assert.deepEqual(readSkillManifest(tmpDir, "team-b"), ["skill-2"]);
+  });
+
+  it("removeSkillManifest cleans up the file", () => {
+    writeSkillManifest(tmpDir, "my-team", ["foo"]);
+    removeSkillManifest(tmpDir, "my-team");
+    assert.deepEqual(readSkillManifest(tmpDir, "my-team"), []);
+  });
+
+  it("removeSkillManifest is safe when no manifest exists", () => {
+    removeSkillManifest(tmpDir, "no-team"); // should not throw
+  });
+
+  it("handles corrupted manifest gracefully", () => {
+    fs.writeFileSync(path.join(tmpDir, ".trc-manifest-bad.json"), "not json");
+    assert.deepEqual(readSkillManifest(tmpDir, "bad"), []);
   });
 });

--- a/cli/src/adapters/base.ts
+++ b/cli/src/adapters/base.ts
@@ -151,6 +151,36 @@ export function listSkillDirIds(baseDir: string): string[] {
     .map((d) => d.slice(4));
 }
 
+/** Manifest file name for tracking which skill IDs a team installed in a directory */
+function skillManifestPath(baseDir: string, teamSlug: string): string {
+  return path.join(baseDir, `.trc-manifest-${teamSlug}.json`);
+}
+
+/** Read the skill manifest for a team from a skills directory.
+ *  Returns the list of skill IDs this team previously installed, or empty if no manifest. */
+export function readSkillManifest(baseDir: string, teamSlug: string): string[] {
+  const p = skillManifestPath(baseDir, teamSlug);
+  if (!fs.existsSync(p)) return [];
+  try {
+    const data = JSON.parse(fs.readFileSync(p, "utf-8"));
+    return Array.isArray(data.skillIds) ? data.skillIds : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Write the skill manifest for a team to a skills directory. */
+export function writeSkillManifest(baseDir: string, teamSlug: string, skillIds: string[]): void {
+  if (!fs.existsSync(baseDir)) fs.mkdirSync(baseDir, { recursive: true });
+  fs.writeFileSync(skillManifestPath(baseDir, teamSlug), JSON.stringify({ skillIds }) + "\n");
+}
+
+/** Remove the skill manifest for a team from a skills directory. */
+export function removeSkillManifest(baseDir: string, teamSlug: string): void {
+  const p = skillManifestPath(baseDir, teamSlug);
+  if (fs.existsSync(p)) fs.unlinkSync(p);
+}
+
 /** List trc-* files in a directory, filtered by extension */
 export function listTrcFiles(dir: string, ext: string = ".md"): string[] {
   if (!fs.existsSync(dir)) return [];

--- a/cli/src/adapters/claude-code.ts
+++ b/cli/src/adapters/claude-code.ts
@@ -16,7 +16,9 @@ import {
   upsertMarkerBlock,
   removeMarkerBlock,
   cleanupSkillDirs,
-  listSkillDirIds,
+  readSkillManifest,
+  writeSkillManifest,
+  removeSkillManifest,
   collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
@@ -204,20 +206,24 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
   }
 
   private writeSkillsAsNativeFiles(team: TeamDefinition, scope: TeamScope): void {
-    const allSkillIds = collectTeamSkillIds(team);
+    const currentSkillIds = collectTeamSkillIds(team);
+    const skillsBaseDir = this.skillsDir(scope);
+    // Union of previously installed + current IDs so stale dirs from renames get cleaned
+    const previousIds = readSkillManifest(skillsBaseDir, this.teamSlug);
+    const allIdsToClean = [...new Set([...previousIds, ...currentSkillIds])];
+
     if (!team.skills || team.skills.length === 0) {
-      // Still clean up old files even if no skills — use existing dirs to find our stale skills
       deleteTrcFiles(this.rulesDir(scope));
-      cleanupSkillDirs(this.skillsDir(scope), listSkillDirIds(this.skillsDir(scope)));
+      cleanupSkillDirs(skillsBaseDir, allIdsToClean);
+      removeSkillManifest(skillsBaseDir, this.teamSlug);
       return;
     }
 
     const rulesDir = this.rulesDir(scope);
-    const skillsBaseDir = this.skillsDir(scope);
 
     // Clean up old files before writing new ones
     deleteTrcFiles(rulesDir);
-    cleanupSkillDirs(skillsBaseDir, allSkillIds);
+    cleanupSkillDirs(skillsBaseDir, allIdsToClean);
 
     for (const skill of team.skills) {
       if (typeof skill.body !== "string") continue;
@@ -271,6 +277,9 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
         fs.writeFileSync(path.join(skillDir, "SKILL.md"), content);
       }
     }
+
+    // Record what we installed so future syncs can clean stale dirs
+    writeSkillManifest(skillsBaseDir, this.teamSlug, currentSkillIds);
   }
 
   private writeBuiltInSkills(knowledgePath: string, scope: TeamScope): void {
@@ -339,13 +348,14 @@ export class ClaudeCodeAdapter implements PlatformAdapter {
       actions.push(`Deleted ${ruleFiles.length} native skill rule(s) from ${rulesDir}`);
     }
 
-    // Delete native skill directories — scoped to known skill IDs when available
+    // Delete native skill directories — use manifest to know what we own
     const skillsDir = this.skillsDir(scope);
-    const idsToClean = skillIds ?? listSkillDirIds(skillsDir);
+    const idsToClean = skillIds ?? readSkillManifest(skillsDir, this.teamSlug);
     const skillCount = cleanupSkillDirs(skillsDir, idsToClean);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} native skill directory(ies) from ${skillsDir}`);
     }
+    removeSkillManifest(skillsDir, this.teamSlug);
 
     // Delete team knowledge
     const projectKnowledgeDir = path.join(process.cwd(), ".teamrc");

--- a/cli/src/adapters/codex.ts
+++ b/cli/src/adapters/codex.ts
@@ -12,7 +12,9 @@ import {
   removeMarkerBlock,
   writeSkillDir,
   cleanupSkillDirs,
-  listSkillDirIds,
+  readSkillManifest,
+  writeSkillManifest,
+  removeSkillManifest,
   collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
@@ -134,7 +136,10 @@ export class CodexAdapter implements PlatformAdapter {
     const teamWithKnowledge = enrichTeamKnowledgeSkill(team, `.teamrc/${knowledgeFileName(this.teamSlug)}`, this.readKnowledge());
 
     // Route skills: alwaysApply/globs → inline in AGENTS.md, on-demand → .agents/skills/
-    cleanupSkillDirs(this.skillsDir(), collectTeamSkillIds(teamWithKnowledge));
+    const currentSkillIds = collectTeamSkillIds(teamWithKnowledge);
+    const previousIds = readSkillManifest(this.skillsDir(), this.teamSlug);
+    const allIdsToClean = [...new Set([...previousIds, ...currentSkillIds])];
+    cleanupSkillDirs(this.skillsDir(), allIdsToClean);
     if (teamWithKnowledge.skills) {
       const dir = this.skillsDir();
       for (const skill of teamWithKnowledge.skills) {
@@ -143,6 +148,7 @@ export class CodexAdapter implements PlatformAdapter {
         }
       }
     }
+    writeSkillManifest(this.skillsDir(), this.teamSlug, currentSkillIds);
 
     // Build set of desired agent filenames and delete orphans
     const desiredFiles = new Set<string>();
@@ -349,12 +355,13 @@ export class CodexAdapter implements PlatformAdapter {
       actions.push("Removed teamrc section from .codex/config.toml");
     }
 
-    // Clean up skill directories — scoped to known skill IDs when available
-    const idsToClean = skillIds ?? listSkillDirIds(this.skillsDir());
+    // Clean up skill directories — use manifest to know what we own
+    const idsToClean = skillIds ?? readSkillManifest(this.skillsDir(), this.teamSlug);
     const skillCount = cleanupSkillDirs(this.skillsDir(), idsToClean);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} teamrc codex skill(s)`);
     }
+    removeSkillManifest(this.skillsDir(), this.teamSlug);
 
     // Clean up knowledge
     for (const deleted of deleteKnowledgeFiles(path.join(process.cwd(), ".teamrc"), this.teamSlug)) {

--- a/cli/src/adapters/cursor.ts
+++ b/cli/src/adapters/cursor.ts
@@ -14,7 +14,9 @@ import {
   upsertMarkerBlock,
   removeMarkerBlock,
   cleanupSkillDirs,
-  listSkillDirIds,
+  readSkillManifest,
+  writeSkillManifest,
+  removeSkillManifest,
   collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
@@ -169,7 +171,10 @@ export class CursorAdapter implements PlatformAdapter {
     for (const f of oldRules) {
       fs.unlinkSync(path.join(this.rulesDir(), f));
     }
-    cleanupSkillDirs(this.skillsDir(), collectTeamSkillIds(teamWithKnowledge));
+    const currentSkillIds = collectTeamSkillIds(teamWithKnowledge);
+    const previousIds = readSkillManifest(this.skillsDir(), this.teamSlug);
+    const allIdsToClean = [...new Set([...previousIds, ...currentSkillIds])];
+    cleanupSkillDirs(this.skillsDir(), allIdsToClean);
 
     // Route skills: alwaysApply/globs → .mdc rule, otherwise → SKILL.md
     if (teamWithKnowledge.skills) {
@@ -187,6 +192,8 @@ export class CursorAdapter implements PlatformAdapter {
     for (const skill of createBuiltInSkills(knowledgePath)) {
       writeSkillDir(this.skillsDir(), skill);
     }
+
+    writeSkillManifest(this.skillsDir(), this.teamSlug, currentSkillIds);
 
     // Build set of desired agent filenames and delete orphans
     const desiredFiles = new Set<string>();
@@ -371,12 +378,13 @@ ${body}
       actions.push(`Deleted ${trcRules.length} teamrc cursor rule(s)`);
     }
 
-    // Clean up skill directories — scoped to known skill IDs when available
-    const idsToClean = skillIds ?? listSkillDirIds(this.skillsDir());
+    // Clean up skill directories — use manifest to know what we own
+    const idsToClean = skillIds ?? readSkillManifest(this.skillsDir(), this.teamSlug);
     const skillCount = cleanupSkillDirs(this.skillsDir(), idsToClean);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} teamrc cursor skill(s)`);
     }
+    removeSkillManifest(this.skillsDir(), this.teamSlug);
 
     // Clean up knowledge
     for (const deleted of deleteKnowledgeFiles(path.join(process.cwd(), ".teamrc"), this.teamSlug)) {

--- a/cli/src/adapters/gemini.ts
+++ b/cli/src/adapters/gemini.ts
@@ -17,7 +17,9 @@ import {
   removeMarkerBlock,
   writeSkillDir,
   cleanupSkillDirs,
-  listSkillDirIds,
+  readSkillManifest,
+  writeSkillManifest,
+  removeSkillManifest,
   collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
@@ -178,9 +180,13 @@ export class GeminiAdapter implements PlatformAdapter {
     // Write to both .agents/skills/ (Gemini CLI) and .agent/skills/ (Antigravity)
     const skillDir = this.skillsDir(scope);
     const antigravityDir = this.antigravitySkillsDir(scope);
-    const allSkillIds = collectTeamSkillIds(teamWithKnowledge);
-    cleanupSkillDirs(skillDir, allSkillIds);
-    cleanupSkillDirs(antigravityDir, allSkillIds);
+    const currentSkillIds = collectTeamSkillIds(teamWithKnowledge);
+    const previousIds = readSkillManifest(skillDir, this.teamSlug);
+    const previousAntigravityIds = readSkillManifest(antigravityDir, this.teamSlug);
+    const allIdsToClean = [...new Set([...previousIds, ...currentSkillIds])];
+    const allAntigravityIds = [...new Set([...previousAntigravityIds, ...currentSkillIds])];
+    cleanupSkillDirs(skillDir, allIdsToClean);
+    cleanupSkillDirs(antigravityDir, allAntigravityIds);
     if (teamWithKnowledge.skills) {
       for (const skill of teamWithKnowledge.skills) {
         if (!skill.alwaysApply && !(skill.globs && skill.globs.length > 0)) {
@@ -199,6 +205,9 @@ export class GeminiAdapter implements PlatformAdapter {
       writeSkillDir(skillDir, skill);
       writeSkillDir(antigravityDir, skill);
     }
+
+    writeSkillManifest(skillDir, this.teamSlug, currentSkillIds);
+    writeSkillManifest(antigravityDir, this.teamSlug, currentSkillIds);
 
     // Write GEMINI.md with team context and always-on skills (use enriched team)
     this.updateGeminiMd(teamWithKnowledge);
@@ -292,13 +301,15 @@ export class GeminiAdapter implements PlatformAdapter {
       actions.push(`Deleted ${trcFiles.length} agent file(s) from ${dir}`);
     }
 
-    // Delete native skill directories (Gemini CLI + Antigravity)
+    // Delete native skill directories — use manifest to know what we own
     const skillsDir = this.skillsDir(scope);
     const antigravityDir = this.antigravitySkillsDir(scope);
-    const idsToClean = skillIds ?? listSkillDirIds(skillsDir);
-    const antigravityIds = skillIds ?? listSkillDirIds(antigravityDir);
+    const idsToClean = skillIds ?? readSkillManifest(skillsDir, this.teamSlug);
+    const antigravityIds = skillIds ?? readSkillManifest(antigravityDir, this.teamSlug);
     const skillCount = cleanupSkillDirs(skillsDir, idsToClean);
     const antigravityCount = cleanupSkillDirs(antigravityDir, antigravityIds);
+    removeSkillManifest(skillsDir, this.teamSlug);
+    removeSkillManifest(antigravityDir, this.teamSlug);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} skill directory(ies) from ${skillsDir}`);
     }

--- a/cli/src/adapters/openclaw.ts
+++ b/cli/src/adapters/openclaw.ts
@@ -9,7 +9,9 @@ import {
   deleteKnowledgeFiles,
   writeSkillDir,
   cleanupSkillDirs,
-  listSkillDirIds,
+  readSkillManifest,
+  writeSkillManifest,
+  removeSkillManifest,
   collectTeamSkillIds,
   resolveAgentSkills,
   enrichTeamKnowledgeSkill,
@@ -180,7 +182,10 @@ export class OpenClawAdapter implements PlatformAdapter {
 
     // Write skills to ~/.openclaw/skills/
     const sharedDir = this.sharedSkillsDir();
-    cleanupSkillDirs(sharedDir, collectTeamSkillIds(teamWithKnowledge));
+    const currentSkillIds = collectTeamSkillIds(teamWithKnowledge);
+    const previousIds = readSkillManifest(sharedDir, this.teamSlug);
+    const allIdsToClean = [...new Set([...previousIds, ...currentSkillIds])];
+    cleanupSkillDirs(sharedDir, allIdsToClean);
     if (teamWithKnowledge.skills) {
       if (!fs.existsSync(sharedDir)) {
         fs.mkdirSync(sharedDir, { recursive: true });
@@ -198,6 +203,9 @@ export class OpenClawAdapter implements PlatformAdapter {
     for (const skill of createBuiltInSkills(knowledgePath)) {
       writeSkillDir(sharedDir, skill);
     }
+
+    // Record installed skills for future cleanup
+    writeSkillManifest(sharedDir, this.teamSlug, currentSkillIds);
 
     // Register agents in openclaw.json
     this.writeAgentsConfig(team);
@@ -310,10 +318,11 @@ export class OpenClawAdapter implements PlatformAdapter {
       }
     }
 
-    // Remove trc- skill directories — scoped to known skill IDs when available
+    // Remove trc- skill directories — use manifest to know what we own
     const sharedDir = this.sharedSkillsDir();
-    const idsToClean = skillIds ?? listSkillDirIds(sharedDir);
+    const idsToClean = skillIds ?? readSkillManifest(sharedDir, this.teamSlug);
     const skillCount = cleanupSkillDirs(sharedDir, idsToClean);
+    removeSkillManifest(sharedDir, this.teamSlug);
     if (skillCount > 0) {
       actions.push(`Deleted ${skillCount} shared skill directory(ies) from ${sharedDir}`);
     }


### PR DESCRIPTION
## Summary

Follow-up to #5 addressing the [remaining gaps](https://github.com/teamrc-ai/teamrc/issues/2#issuecomment-4070095938) called out on #2:

1. **Claude zero-skills path** — was still calling `listSkillDirIds` (lists all `trc-*` dirs in the root). Now reads the team's manifest instead.
2. **Delete with missing YAML** — uninstall was falling back to `listSkillDirIds` when `skillIds` was undefined. Now falls back to the manifest.
3. **Stale dirs from renamed/removed skills** — cleanup now unions the manifest (what we installed last time) with current skill IDs, so old dirs get cleaned on the next sync.

## How it works

Each adapter now writes `.trc-manifest-{slug}.json` alongside its skill directories during `writeTeam`. The manifest records exactly which skill IDs this team installed. On the next sync or uninstall, the adapter reads the manifest to know what it owns — no more guessing from directory listings.

| File | Change |
|------|--------|
| `adapters/base.ts` | `readSkillManifest`, `writeSkillManifest`, `removeSkillManifest` |
| `adapters/*.ts` (all 5) | Write manifest after skills, read manifest for cleanup/uninstall |
| `__tests__/base-utils.test.ts` | 7 new tests for manifest round-trip, slug isolation, corruption |

## Test plan

- [x] Manifest round-trips skill IDs correctly
- [x] Manifests are isolated per team slug in shared directories
- [x] Corrupted manifest returns empty array (fail closed)
- [x] `removeSkillManifest` is safe when no manifest exists
- [x] All 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)